### PR TITLE
fix(proxy): updated cookie name to not conflict with Overseerr cookie

### DIFF
--- a/plex-shuffler-api.yml
+++ b/plex-shuffler-api.yml
@@ -362,7 +362,7 @@ components:
   securitySchemes:
     cookieAuth:
       type: apiKey
-      name: connect.sid
+      name: plex-shuffler.connect.sid
       in: cookie
     apiKey:
       type: apiKey

--- a/server/index.ts
+++ b/server/index.ts
@@ -118,6 +118,7 @@ app
     server.use(
       '/api',
       session({
+        name: 'plex-shuffler.connect.sid',
         secret: settings.clientId,
         resave: false,
         saveUninitialized: false,


### PR DESCRIPTION
cookie name updated to plex-shuffler.connect.sid